### PR TITLE
fix:use configured editor url instead of localhost

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,7 +39,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (
   }
 
   const props = await getJsonBody<PageProps>(context)
-  const response = await fetch('http://localhost:3000/lti/get-content', {
+  const response = await fetch(process.env.EDITOR_URL + 'lti/get-content', {
     headers: {
       Authorization: `Bearer ${props.ltik}`,
     },


### PR DESCRIPTION
Hi!

We had issues that the client didn't seem to contact the proper server in a K8S deployment.

With this fix, it worked for us. Can you please verify if the change is correct?