### PR TITLE
fix: use the embedding nodeId as https://purl.imsglobal.org/spec/lti/…

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ Provider.setup(
 
 Provider.onConnect(async (token, req, res) => {
   const { custom } = res.locals.context
-
+  
   const response = await fetch('http://localhost:3000', {
     method: 'POST',
     headers: {
@@ -50,7 +50,8 @@ Provider.onConnect(async (token, req, res) => {
       mayEdit:
         custom !== undefined && typeof custom.postContentApiUrl === 'string',
       ltik: res.locals.ltik,
-      user: custom.user
+      user: custom.user,
+      nodeId: custom.nodeId
     }),
   })
   res.send(await response.text())
@@ -72,10 +73,7 @@ void (async () => {
       aud: process.env.EDITOR_CLIENT_ID,
       "https://purl.imsglobal.org/spec/lti/claim/deployment_id" : process.env.EDITOR_DEPLOYMENT_ID,
       expiresIn: 60,
-      dataToken: token.platformContext.custom.dataToken,
-      'https://purl.imsglobal.org/spec/lti/claim/context': {
-        id: process.env.EDITOR_CLIENT_ID,
-      }
+      dataToken: token.platformContext.custom.dataToken
     }
 
     // TODO: Duplicate code

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -58,6 +58,9 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (
   if (props.ltik) {
     edusharingConfig.ltik = props.ltik
   }
+  if (props.nodeId) {
+    edusharingConfig.nodeId = props.nodeId
+  }
 
   return {
     props: {
@@ -73,6 +76,7 @@ export interface PageProps extends EditorProps {
   mayEdit: boolean
   user?: string
   dataToken?: string
+  nodeId: string
 }
 
 export default function Page(props: PageProps) {

--- a/src/pages/platform/login.tsx
+++ b/src/pages/platform/login.tsx
@@ -4,7 +4,7 @@ import { GetServerSideProps } from 'next'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   // TODO: verify token
-
+  
   // TODO: Use session to give information further
   // TODO: Proper parsing
   const messageHintParam = context.query['lti_message_hint'] as string
@@ -31,7 +31,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     'https://purl.imsglobal.org/spec/lti/claim/version': '1.3.0',
     'https://purl.imsglobal.org/spec/lti/claim/roles': [],
     'https://purl.imsglobal.org/spec/lti/claim/context': {
-      id: process.env.EDITOR_CLIENT_ID,
+      id: messageHint.nodeId,
     },
 
     ...(messageHint.type === 'deep-link'
@@ -107,6 +107,7 @@ interface DeepLinkMessage {
   type: 'deep-link'
   user: string
   dataToken: string
+  nodeId: string
 }
 
 interface ResourceLinkMessage {
@@ -114,4 +115,5 @@ interface ResourceLinkMessage {
   user: string
   dataToken: string
   resourceLink: string
+  nodeId: string
 }

--- a/src/plugins/edusharing-asset.tsx
+++ b/src/plugins/edusharing-asset.tsx
@@ -31,6 +31,7 @@ export interface EdusharingConfig {
   ltik?: string
   user?: string
   dataToken?: string
+  nodeId?: string
 }
 
 type State = typeof state
@@ -141,6 +142,7 @@ function EdusharingAsset({ state, editable, focused, config }: Props) {
         type: 'deep-link',
         user: getUser(),
         dataToken: getDataToken(),
+        nodeId: getNodeId()
       },
     })
 
@@ -197,5 +199,9 @@ function EdusharingAsset({ state, editable, focused, config }: Props) {
 
   function getDataToken() {
     return config.dataToken ?? ''
+  }
+
+  function getNodeId() {
+    return config.nodeId ?? ''
   }
 }


### PR DESCRIPTION
edu-sharing needs the information which nodes are embedded in other nodes without parsing editor content.
the lti context attribute is used to transfer this.