### PR TITLE
Fix bug: Opening content preview on edu-sharing shows error message in local dev environment. 

### DIFF
--- a/src/shared/decoders.ts
+++ b/src/shared/decoders.ts
@@ -25,12 +25,12 @@ export const DeeplinkLoginData = t.type({
 export const LtiCustomType = t.intersection([
   t.type({
     getContentApiUrl: t.string,
-    getDetailsSnippetUrl: t.string,
     appId: t.string,
   }),
   DeeplinkLoginData,
   t.partial({
     fileName: t.string,
+    /** Is set when editor was opened in edit mode */
     postContentApiUrl: t.string,
     version: t.string,
   }),


### PR DESCRIPTION
edu-sharing does send us a getDetailsSnippetUrl during a launch in edit-mode, but not in readonly-mode. This change and deleting the docker volumes solved the bug, where the content preview in the local dev environment showed error "Kommunikation mit dem Remote-System ..."